### PR TITLE
Buildisos

### DIFF
--- a/build-isos
+++ b/build-isos
@@ -19,6 +19,7 @@ cd "$here"
 for image in "${IMAGES[@]}"; do
 	image="${image#recipe-}"
 	image="${image%.yml}"
+	#docker run --rm --privileged --volume "$outdir":/build-container-installer/build --pull=always \
 	podman run --rm --privileged --volume "$outdir":/build-container-installer/build --security-opt label=disable --pull=newer \
 		ghcr.io/jasonn3/build-container-installer:latest \
 		IMAGE_REPO=ghcr.io/omegasquad82 \
@@ -26,5 +27,5 @@ for image in "${IMAGES[@]}"; do
 		IMAGE_TAG="$image_tag" \
 		VARIANT="$variant" \
 		VERSION="$version" \
-		ISO_NAME="$image-$image_tag-f$version-$(date -I)".iso
+		ISO_NAME="$outdir/$image-$image_tag-f$version-$(date -I)".iso
 done

--- a/recipes/common-packages.yml
+++ b/recipes/common-packages.yml
@@ -3,7 +3,6 @@ modules:
     install:
       - byobu
       - kitty
-      - htop
       - neovim
       - powertop
       - tlp

--- a/recipes/common-podman.yml
+++ b/recipes/common-podman.yml
@@ -1,0 +1,5 @@
+modules:
+  - type: systemd
+    system:
+      enabled:
+        - podman.service

--- a/recipes/recipe-borealis.yml
+++ b/recipes/recipe-borealis.yml
@@ -6,4 +6,5 @@ image-version: 40
 
 modules:
   - from-file: common-modules.yml
+  - from-file: common-podman.yaml
   - type: signing

--- a/recipes/recipe-buttgenbachit.yml
+++ b/recipes/recipe-buttgenbachit.yml
@@ -7,4 +7,5 @@ image-version: stable
 modules:
   - from-file: common-modules.yml
   - from-file: common-bazzite.yml
+  - from-file: common-podman.yaml
   - type: signing

--- a/recipes/recipe-flaviramea.yml
+++ b/recipes/recipe-flaviramea.yml
@@ -6,20 +6,12 @@ image-version: 40
 
 modules:
   - from-file: common-modules.yml
-
+  - from-file: common-podman.yaml
   - type: rpm-ostree
-    install:
-      - gdisk
     remove:
       - firefox
       - firefox-langpacks
-
   - type: brew
-    nofile-limits: true # increase nofile limits
-    brew-analytics: false # disable telemetry
-
-  - type: bling
-    install:
-      - ublue-update # https://github.com/ublue-os/ublue-update
-
+    nofile-limits: true
+    brew-analytics: false
   - type: signing


### PR DESCRIPTION
htop is already part of ublue-os/main/packages.json
gdisk and ublue-update are unnecessary, really.
enable podman on my personal desktops.