### PR TITLE
Disabled lact to test if rechunk terminates 0

### DIFF
--- a/recipes/recipe-buttgenbachit.yml
+++ b/recipes/recipe-buttgenbachit.yml
@@ -23,7 +23,7 @@ modules:
   - from-file: configs/podman.yml
   - from-file: configs/tailscale.yml
 
-  - from-file: configs/amdgpu.yml
+  # - from-file: configs/amdgpu.yml
   - from-file: configs/bazzite.yml
   - from-file: configs/packages.yml
   - from-file: configs/flatpaks.yml

--- a/recipes/recipe-buttgenbachit.yml
+++ b/recipes/recipe-buttgenbachit.yml
@@ -19,7 +19,7 @@ modules:
   - from-file: configs/zram-generator.yml
 
   - from-file: configs/sshd.yml
-  - from-file: configs/fonts.yml
+  # - from-file: configs/fonts.yml
   - from-file: configs/podman.yml
   - from-file: configs/tailscale.yml
 


### PR DESCRIPTION
currently it exits right after:

"[12:08:43 g.i/h/rechunk:v1.0.1] => Creating archive with ref oci:6a3da461-2bae-4d39-ba0f-ef8dd816305e"

with

"[12:13:46 g.i/h/rechunk:v1.0.1] => error: Building oci: Writing ostree root to blob: Exporting chunk 70: Writing regfile 4e2f30cd413e8b6a361de858f603701b82b1aaec42b0ffa7942b1659abdf3860: No space left on device (os error 28)
[12:13:55 ERROR] => Failed:

  × Failed to run rechunking for ghcr.io/omegasquad82/buttgenbachit

Error: Process completed with exit code 1."