### PR TITLE
fix: slow down zram recompression timer but process more pages (33% net increase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ It is important to know that in ZRAM terms _incompressible_ pages are called `hu
 
 #### Implementation
 
-ZRAM is [configured](files/system/etc/systemd/zram-generator.conf) to use `lz4` as a fast, low-latency compression algorithm and both `zstd` and `lz4hc` were selected as secondary ones. A default to once every second try to recompress a maximum of `1024` pages (up to 4 MiB) was selected to not produce unduly burden on the CPU. Any previous discrimination between either `idle` or `huge` pages has been removed for simplicity and no script files are being used.
+ZRAM is [configured](files/system/etc/systemd/zram-generator.conf) to use `lz4` as a fast, low-latency compression algorithm and both `zstd` and `lz4hc` were selected as secondary ones. A default to once every `3s` try to recompress a maximum of `4096` pages (up to 16 MiB) was selected to not produce unduly burden on the CPU. Any previous discrimination between either `idle` or `huge` pages has been removed for simplicity and no script files are being used.
 
 The system uses a [zram-recompression.timer](files/system/etc/systemd/system/zram-recompression.timer) to orchestrate the one-off execution of a [zram-recompression.service](files/system/etc/systemd/system/zram-recompression.service). Since freed memory is likely to become fragmented over time another set of systemd units, a [zram-compaction.service](files/system/etc/systemd/system/zram-compaction.service) and a [zram-compaction.timer](files/system/etc/systemd/system/zram-compaction.timer) have been created. The Service units are designed to trigger either compaction or recompression for all existing ZRAM devices. Timers add a randomized delay of up to 10% to the cycle time.
 

--- a/files/system/etc/systemd/system/zram-recompression.service
+++ b/files/system/etc/systemd/system/zram-recompression.service
@@ -6,4 +6,4 @@ StopWhenUnneeded=yes
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/bash -c "printf 'max_pages=1024' >/sys/block/zram*/recompress"
+ExecStart=/usr/bin/bash -c "printf 'max_pages=4096' >/sys/block/zram*/recompress"

--- a/files/system/etc/systemd/system/zram-recompression.timer
+++ b/files/system/etc/systemd/system/zram-recompression.timer
@@ -3,8 +3,8 @@ Description=Control timing to recompress ZRAM pages
 
 [Timer]
 OnBootSec=3min
-OnUnitActiveSec=1s
-RandomizedDelaySec=100ms
+OnUnitActiveSec=3s
+RandomizedDelaySec=300ms
 Unit=zram-recompression.service
 
 [Install]


### PR DESCRIPTION
…crease) due to error messages of systemd (too fast triggering) and the kernel (memory exhaustion)